### PR TITLE
[RTT6] Filter out old kafka messages

### DIFF
--- a/backend/real_time_trading/constants.py
+++ b/backend/real_time_trading/constants.py
@@ -43,10 +43,12 @@ KAFKA_HOST: str = "localhost"
 KAFKA_PORT: int = 9092
 KAFKA_BOOTSTRAP_SERVERS: str = f"{KAFKA_HOST}:{KAFKA_PORT}"
 
-ROOT_DIR: str = "~/src/real-time-trading"
+ROOT_DIR: str = "/home/hongruliu/src/real-time-trading"
 
 IBAPP_LOG_FILE: str = f"{ROOT_DIR}/logs/ibapp.log"
 RTT_LOG_FILE: str = f"{ROOT_DIR}/logs/real_time_trading.log"
 APP_LOG_FILE: str = f"{ROOT_DIR}/logs/app.log"
+
+DATA_DIR: str = f"{ROOT_DIR}/data/raw_ticker"
 
 SECONDS_BEFORE_RECONNECT: int = 20

--- a/backend/real_time_trading/ib_app.py
+++ b/backend/real_time_trading/ib_app.py
@@ -94,7 +94,9 @@ if __name__ == "__main__":
     raw_ticker_kafka_handler = RawTickerKafkaHandler(
         topic=constants.RAW_TICKER_EVENT,
     )
-    raw_ticker_file_handler = RawTickerFileHandler(directory="data/raw_ticker")
+    raw_ticker_file_handler = RawTickerFileHandler(
+        directory=constants.DATA_DIR,
+    )
     HANDLERS: list[Handler] = [
         raw_ticker_kafka_handler,
         raw_ticker_file_handler,

--- a/backend/real_time_trading/ib_app.py
+++ b/backend/real_time_trading/ib_app.py
@@ -23,8 +23,8 @@ formatter = logging.Formatter(
     "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 ch = logging.StreamHandler()
 ch.setLevel(logging.INFO)

--- a/backend/real_time_trading/objects/intraday_ticker.py
+++ b/backend/real_time_trading/objects/intraday_ticker.py
@@ -129,6 +129,7 @@ class IntradayTicker:
                 constants.INTRADAY_HIGH_EVENT,
                 key=self.contract.symbol,
                 value=intraday_high.to_event_message(),
+                timestamp_ms=raw_ticker.time.timestamp_ms(),
             )
             logger.info("sending intraday high event")
             self.intraday_high = raw_ticker.last
@@ -146,6 +147,7 @@ class IntradayTicker:
                 constants.INTRADAY_LOW_EVENT,
                 key=self.contract.symbol,
                 value=intraday_low.to_event_message(),
+                timestamp_ms=raw_ticker.time.timestamp_ms(),
             )
             logger.info("sending intraday low event")
             self.intraday_low = raw_ticker.last

--- a/backend/real_time_trading/objects/top_symbol.py
+++ b/backend/real_time_trading/objects/top_symbol.py
@@ -63,7 +63,7 @@ class TopNSymbols:
     @staticmethod
     def from_message(message: dict[str, Any]) -> TopNSymbols:
         return TopNSymbols(
-            time=message["time"],
+            time=UTCDateTime.from_isoformat(message["time"]),
             top_symbols=[
                 TopSymbol.from_event_message(m) for m in message["data"]
             ],

--- a/backend/real_time_trading/objects/utc_datetime.py
+++ b/backend/real_time_trading/objects/utc_datetime.py
@@ -52,7 +52,8 @@ class UTCDateTime(datetime):
 
     @classmethod
     def now(cls, tz: tzinfo | None = None) -> UTCDateTime:
-        logger.warning("UTCDateTime is always in UTC, ignoring tz")
+        if tz is not None:
+            logger.warning("UTCDateTime is always in UTC, ignoring tz")
         return UTCDateTime.from_timezone_naive(datetime.utcnow())
 
     # TODO: refactor this out of the class
@@ -99,6 +100,11 @@ class UTCDateTime(datetime):
         )
 
     @classmethod
+    def from_timestamp(cls, timestamp: float) -> UTCDateTime:
+        dt = datetime.utcfromtimestamp(timestamp)
+        return cls.from_timezone_naive(dt)
+
+    @classmethod
     def from_utc(cls, dt: datetime) -> UTCDateTime:
         """Convert datetime that is already in UTC to UTCDateTime.
         The datetime may or may not be timezone aware.
@@ -134,3 +140,6 @@ class UTCDateTime(datetime):
 
     def __str__(self):
         return self.isoformat()
+
+    def timestamp_ms(self) -> int:
+        return int(self.timestamp() * 1000)

--- a/backend/real_time_trading/trader.py
+++ b/backend/real_time_trading/trader.py
@@ -140,6 +140,7 @@ class Trader:
             self._top_symbol_producer.send(
                 constants.TOP_HIGH_EVENT,
                 value=self.top_n_symbols.to_message(),
+                timestamp_ms=time.timestamp_ms(),
             )
             logger.info("sending top high event")
         bottom_n_symbols = self.get_bottom_n_tickers(
@@ -155,6 +156,7 @@ class Trader:
             self._top_symbol_producer.send(
                 constants.TOP_LOW_EVENT,
                 value=self.bottom_n_symbols.to_message(),
+                timestamp_ms=time.timestamp_ms(),
             )
             logger.info("sending top low event")
 

--- a/backend/real_time_trading/trader.py
+++ b/backend/real_time_trading/trader.py
@@ -41,6 +41,7 @@ class Trader:
     def __init__(
         self,
         contracts: list[Stock],
+        start_time: UTCDateTime | None = None,
         bake_in_minutes: int = 0,
         bake_out_minutes: int = 0,
         n_top_tickers: int = 4,
@@ -55,6 +56,9 @@ class Trader:
             value_deserializer=utils.bytes2object,
             auto_offset_reset="earliest",
         )
+        # set up consumer to start from start_time
+        utils.set_offsets_by_time(self._consumer, start_time)
+
         # shared producer for all tickers
         self._intraday_producer = KafkaProducer(
             bootstrap_servers=constants.KAFKA_BOOTSTRAP_SERVERS,
@@ -199,5 +203,9 @@ class Trader:
 
 if __name__ == "__main__":
     CONTRACTS = [Stock(**stk) for stk in constants.CONTRACTS]
-    rtt = Trader(contracts=CONTRACTS, _bypass_update_window=True)
+    rtt = Trader(
+        contracts=CONTRACTS,
+        start_time=None,
+        _bypass_update_window=True,
+    )
     rtt.consume()

--- a/backend/real_time_trading/trader.py
+++ b/backend/real_time_trading/trader.py
@@ -15,16 +15,14 @@ from real_time_trading.objects.top_symbol import TopNSymbols
 from real_time_trading.objects.utc_datetime import UTCDateTime
 
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-logging.getLogger("kafka").setLevel(logging.DEBUG)
+logging.getLogger("kafka").setLevel(logging.WARN)
 
 formatter = logging.Formatter(
     "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 ch = logging.StreamHandler()
 ch.setLevel(logging.INFO)

--- a/backend/real_time_trading/utils.py
+++ b/backend/real_time_trading/utils.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
+import logging
 import os
 import pickle
 from datetime import datetime
 from datetime import timezone
 from typing import Any
-from typing import Union
 
 import exchange_calendars as xcals
 from aiokafka import AIOKafkaConsumer
 from kafka import KafkaConsumer
+from kafka import TopicPartition
 from real_time_trading.objects.utc_datetime import UTCDateTime
 
 
-_KafkaConsumer = Union[KafkaConsumer, AIOKafkaConsumer]
+logger = logging.getLogger(__name__)
 
 
 def camel_to_snake(name: str) -> str:
@@ -108,8 +109,10 @@ def get_local_now() -> datetime:
 
 
 def set_offsets_by_time(
-    consumer: _KafkaConsumer, start_time: UTCDateTime | None = None,
+    consumer: KafkaConsumer,
+    start_time: UTCDateTime | None = None,
 ):
+    logger.info("setting offsets by time %s", start_time)
     if start_time is None:
         local_now = get_local_now()
         start_time = UTCDateTime(
@@ -118,10 +121,45 @@ def set_offsets_by_time(
             local_now.day,
             tzinfo=local_now.tzinfo,
         )
-    partitions = consumer.assignment()
+    topics = consumer.subscription()
+    partitions = []
+    if not topics:
+        return
+    for t in topics:
+        parts = consumer.partitions_for_topic(t)
+        if parts is None:
+            continue
+        for p in parts:
+            partitions.append(TopicPartition(t, p))
+    # partitions = consumer.assignment()
     partition_to_timestamp = {
         part: start_time.timestamp_ms() for part in partitions
     }
     mapping = consumer.offsets_for_times(partition_to_timestamp)
     for partition, ts in mapping.items():  # type: ignore
+        logger.info("setting offset for partition %s to %s", partition, ts[0])
+        consumer.seek(partition, ts[0])
+
+
+async def set_offsets_by_time_aiokafka(
+    consumer: AIOKafkaConsumer,
+    start_time: UTCDateTime | None = None,
+):
+    logger.info("setting offsets by time %s", start_time)
+    if start_time is None:
+        local_now = get_local_now()
+        start_time = UTCDateTime(
+            local_now.year,
+            local_now.month,
+            local_now.day,
+            tzinfo=local_now.tzinfo,
+        )
+
+    partitions = consumer.assignment()
+    partition_to_timestamp = {
+        part: start_time.timestamp_ms() for part in partitions
+    }
+    mapping = await consumer.offsets_for_times(partition_to_timestamp)
+    for partition, ts in mapping.items():  # type: ignore
+        logger.info("setting offset for partition %s to %s", partition, ts[0])
         consumer.seek(partition, ts[0])

--- a/backend/real_time_trading/websocket.py
+++ b/backend/real_time_trading/websocket.py
@@ -27,7 +27,8 @@ CONTRACTS = [Stock(**stk) for stk in constants.CONTRACTS]
 formatter = logging.Formatter(
     "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
-logger = logging.getLogger(__name__)
+
+logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 ch = logging.StreamHandler()
@@ -81,8 +82,8 @@ async def consume_intraday_events(websocket):
         value_deserializer=utils.bytes2object,
         auto_offset_reset="earliest",
     )
-    utils.set_offsets_by_time(consumer)
     await consumer.start()  # type: ignore
+    await utils.set_offsets_by_time_aiokafka(consumer)
     try:
         async for msg in consumer:
             if msg.value:
@@ -100,8 +101,8 @@ async def consume_top_symbol_events(websocket):
         value_deserializer=utils.bytes2object,
         auto_offset_reset="earliest",
     )
-    utils.set_offsets_by_time(consumer)
     await consumer.start()  # type: ignore
+    await utils.set_offsets_by_time_aiokafka(consumer)
     try:
         async for msg in consumer:
             if msg.value:

--- a/backend/real_time_trading/websocket.py
+++ b/backend/real_time_trading/websocket.py
@@ -81,6 +81,7 @@ async def consume_intraday_events(websocket):
         value_deserializer=utils.bytes2object,
         auto_offset_reset="earliest",
     )
+    utils.set_offsets_by_time(consumer)
     await consumer.start()  # type: ignore
     try:
         async for msg in consumer:
@@ -99,6 +100,7 @@ async def consume_top_symbol_events(websocket):
         value_deserializer=utils.bytes2object,
         auto_offset_reset="earliest",
     )
+    utils.set_offsets_by_time(consumer)
     await consumer.start()  # type: ignore
     try:
         async for msg in consumer:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aiokakfa
 exchange_calendars
 ib_insync
 kafka-python
+nb_black
 nest_asyncio
 pre-commit
 pytest


### PR DESCRIPTION
#6

- use ticker time as kafka time
- add offsets setting for both `KafkaConsumer` and `AIOKafkaConsumer`
- fix bugs
- fix root level logger